### PR TITLE
Use correct definition for "journey{man,woman}"

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -179,8 +179,8 @@ And-patterns operate on a per-paragraph level.
 | `boyfriends-girlfriends` | [or](#or) | `girlfriends` (female), `boyfriends` (male) | `partners`, `friends`, `significant others` |
 | `boyhood-girlhood` | [or](#or) | `girlhood` (female), `boyhood` (male) | `childhood` |
 | `boyish-girly` | [or](#or) | `girly` (female), `girlish` (female), `boyish` (male) | `childish` |
-| `journeyman-journeywoman` | [or](#or) | `journeywoman` (female), `journeyman` (male) | `traveler` |
-| `journeymen-journeywomen` | [or](#or) | `journeywomen` (female), `journeymen` (male) | `travelers` |
+| `journeyman-journeywoman` | [or](#or) | `journeywoman` (female), `journeyman` (male) | `journeyperson` |
+| `journeymen-journeywomen` | [or](#or) | `journeywomen` (female), `journeymen` (male) | `journeypersons` |
 | `godfather-godmother` | [or](#or) | `godmother` (female), `patroness` (female), `godfather` (male) | `godparent`, `elder`, `patron` |
 | `granddaughter-grandson` | [or](#or) | `granddaughter` (female), `grandson` (male) | `grandchild` |
 | `granddaughters-grandsons` | [or](#or) | `granddaughters` (female), `grandsons` (male) | `grandchildren` |

--- a/script/gender.yml
+++ b/script/gender.yml
@@ -641,13 +641,13 @@
     boyish: male
 - type: or
   considerate:
-    - traveler
+    - journeyperson
   inconsiderate:
     journeywoman: female
     journeyman: male
 - type: or
   considerate:
-    - travelers
+    - journeypersons
   inconsiderate:
     journeywomen: female
     journeymen: male

--- a/test.js
+++ b/test.js
@@ -230,6 +230,12 @@ test('Phrasing', function (t) {
   );
 
   t.same(
+    process('A journeyman arrived'),
+    ['1:3-1:13: `journeyman` may be insensitive, use `journeyperson` instead'],
+    'A journeyman arrived'
+  );
+
+  t.same(
     process('I’m not psychotic, I didn’t have amnesia yesterday.'),
     ['1:9-1:18: `psychotic` may be insensitive, use `person with a psychotic condition`, `person with psychosis` instead'],
     'I’m not psychotic, I didn’t have amnesia yesterday'


### PR DESCRIPTION
"Journeyman" and "journeywoman" don't have anything to do with travel; instead, they [refer](https://en.wiktionary.org/wiki/journeyman) to a trade worker at an intermediate level between apprenticeship and mastery.