### PR TITLE
Check for make-something-great-again references using wildcard #41

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -336,6 +336,7 @@ And-patterns operate on a per-paragraph level.
 | `orientals` | [simple](#simple) | `orientals` | `Asian people` |
 | `nonwhite` | [simple](#simple) | `nonwhite`, `non white` | `person of color`, `people of color` |
 | `ghetto` | [simple](#simple) | `ghetto` | `projects`, `urban` |
+| `make-*-great-again` | [simple](#simple) | `make * great again`, `make * * great again`, `make * * * great again`, `make * * * * great again` | `improve` |
 | `committed-suicide` | [simple](#simple) | `committed suicide`, `completed suicide` | `died by suicide` |
 | `commit-suicide` | [simple](#simple) | `commit suicide`, `complete suicide` | `die by suicide` |
 | `suicide-epidemic` | [simple](#simple) | `suicide epidemic` | `rise in suicides` |

--- a/rules.md
+++ b/rules.md
@@ -336,7 +336,7 @@ And-patterns operate on a per-paragraph level.
 | `orientals` | [simple](#simple) | `orientals` | `Asian people` |
 | `nonwhite` | [simple](#simple) | `nonwhite`, `non white` | `person of color`, `people of color` |
 | `ghetto` | [simple](#simple) | `ghetto` | `projects`, `urban` |
-| `make-*-great-again` | [simple](#simple) | `make * great again`, `make * * great again`, `make * * * great again`, `make * * * * great again` | `improve` |
+| `make-*-great-again` | [simple](#simple) | `make * great again`, `make * * great again`, `make * * * great again`, `make * * * * great again`, `make * * * * * great again` | `improve` |
 | `committed-suicide` | [simple](#simple) | `committed suicide`, `completed suicide` | `died by suicide` |
 | `commit-suicide` | [simple](#simple) | `commit suicide`, `complete suicide` | `die by suicide` |
 | `suicide-epidemic` | [simple](#simple) | `suicide epidemic` | `rise in suicides` |

--- a/script/slogans.yml
+++ b/script/slogans.yml
@@ -1,0 +1,9 @@
+- type: simple
+  considerate:
+    - improve
+  inconsiderate:
+    - make * great again
+    - make * * great again
+    - make * * * great again
+    - make * * * * great again
+    - make * * * * * great again

--- a/test.js
+++ b/test.js
@@ -355,6 +355,12 @@ test('Phrasing', function (t) {
     'wife-beater.'
   );
 
+  t.same(
+    process('We will make this event great again'),
+    ['1:9-1:13: `make this event great again` may be insensitive, use `improve` instead'],
+    'We will make this event great again'
+  );
+
   t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -361,6 +361,12 @@ test('Phrasing', function (t) {
     'We will make this event great again'
   );
 
+  t.same(
+    process('We will make something great again'),
+    ['1:9-1:13: `make something great again` may be insensitive, use `improve` instead'],
+    'We will make something great again'
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
Closes #41 

This PR adds rules and tests for catching uses of "make _____ great again".

### What changed

I added rules with multi-word wildcards:

```
    - make * great again
    - make * * great again
    - make * * * great again
    - make * * * * great again
    - make * * * * * great again
```

This was done because frequently when a joke/pun is made with this phrase, it uses multiple words, like "With this new round of fundraising, we'll make **our building** great again!" I think this is a nice middle ground where we don't match across the whole paragraph with `and`, but we catch some more nuance.

I put the rules in a new file, `slogans.yml`. It didn't seem to fit neatly in any category because it's kind of related to multiple existing files. Let me know if you want me to move it or rename it.

I also added two tests: single-word use and multi-word use.

Thank you! Feel free to edit my PR directly or request changes.