### PR TITLE
resolve duplicate Contributing sections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,18 +67,22 @@ processed [virtual file][vfile]s.
 `he` is warned about unless it’s followed by something like `or she` or
 `and she`.  When `noBinary` is `true`, both cases would be warned about.
 
-## Contributing
-
-Thanks, contributions are greatly appreciated!  :+1:  If you add new
-patterns, add them in the YAML files in the [`script/`][script]
-directory, and run `npm install` and then `npm test` to build
-everything.
-
-Please see the current patterns for inspiration.
-
 ## Rules
 
 See [`rules.md`][rules] for a list of rules.
+
+## Contributing
+
+Thanks, contributions are greatly appreciated!  :+1: 
+See [`contributing.md` in `retextjs/retext`][contributing] for ways to get
+started.  This organisation has a [Code of Conduct][coc].  By interacting 
+with this repository, organisation, or community you agree to abide by its
+terms.
+
+To create new patterns, add them in the YAML files in the 
+[`script/`][script] directory, and run `npm install` and then `npm test` 
+to build everything.  New rules will be automatically added to `rules.md`.
+Please see the current patterns for inspiration.
 
 ## Related
 
@@ -88,14 +92,6 @@ See [`rules.md`][rules] for a list of rules.
     — Check for profane and vulgar wording
 *   [`retext-simplify`](https://github.com/retextjs/retext-simplify)
     — Check phrases for simpler alternatives
-
-## Contribute
-
-See [`contributing.md` in `retextjs/retext`][contributing] for ways to get
-started.
-
-This organisation has a [Code of Conduct][coc].  By interacting with this
-repository, organisation, or community you agree to abide by its terms.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,9 @@ To create new patterns, add them in the YAML files in the
 to build everything.  New rules will be automatically added to `rules.md`.
 Please see the current patterns for inspiration.
 
+Once you are happy with the new rule, add a test for it in
+[`test.js`][test] and open a Pull Request.
+
 ## Related
 
 *   [`retext-passive`](https://github.com/retextjs/retext-passive)
@@ -122,6 +125,8 @@ Please see the current patterns for inspiration.
 [vfile]: https://github.com/vfile/vfile
 
 [script]: script
+
+[test]: test.js
 
 [rules]: rules.md
 


### PR DESCRIPTION
## Changed
While reviewing to prep for Hacktoberfest, the only issue I noticed with the README was that there are two Contributing sections. I combined them into 1 and moved them below "Rules". 

## Added

- a sentence to show that rules get automatically added. I made the mistake of trying to draft something during my first PR, and got confused when it was wiped out.
- reminder to include tests for new features

After any requested changes to this are made, the same text could be added to [https://github.com/retextjs/retext-profanities](https://github.com/retextjs/retext-profanities). That itself could be a good hacktoberfest issue for someone else to do, or I'm happy to help out.