### PR TITLE
Add some notes to the ablist file 

### DIFF
--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -81,7 +81,7 @@
     - nuts
 - type: simple
   source: http://ncdj.org/style-guide/
-  note: Only refer to terms describing mental illness when referring to a professionally diagnosed medical condition.
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - fluctuating
     - person with bipolar disorder
@@ -89,7 +89,7 @@
     - bipolar
 - type: simple
   source: http://ncdj.org/style-guide/
-  note: Only refer to terms describing mental illness when referring to a professionally diagnosed medical condition.
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - person with schizophrenia
   inconsiderate:
@@ -183,6 +183,7 @@
     - holds back
   inconsiderate: retards
 - type: simple
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - person with a psychotic condition
     - person with psychosis
@@ -417,6 +418,7 @@
     - detox
 - type: simple
   source: http://ncdj.org/style-guide/
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - person with a personality disorder
     - person with psychopathic personality
@@ -424,6 +426,7 @@
     - sociopath
 - type: simple
   source: http://ncdj.org/style-guide/
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - people with psychopathic personalities
     - people with a personality disorder
@@ -463,6 +466,7 @@
     - anorexic
 - type: simple
   source: http://english.stackexchange.com/questions/247550/
+  note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - obsessive
     - pedantic

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -206,11 +206,12 @@
     - special olympic athletes
 - type: simple
   source: http://ncdj.org/style-guide/
-  note: Sometimes `typical` can be used.
+  note: Can imply that people with disabilities lack the ability to use their bodies well. Sometimes `typical` can be used.
   considerate:
     - non-disabled
   inconsiderate:
     - ablebodied
+    - able-bodied
 - type: simple
   source: http://ncdj.org/style-guide/
   considerate:

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -34,7 +34,7 @@
   considerate:
     - people with intellectual disabilities
   inconsiderate:
-    - sabled people
+    - intellectually disabled people
 - type: simple
   source: http://ncdj.org/style-guide/
   considerate:
@@ -43,7 +43,7 @@
     - intellectually disabled
 - type: simple
   source: http://ncdj.org/style-guide/
-  note: Assumes that a person with an intellectually disability has a reduced quality of life.
+  note: Assumes that a person with an intellectual disability has a reduced quality of life.
   considerate:
     - person with an intellectual disability
   inconsiderate:

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -18,6 +18,8 @@
   inconsiderate:
     - birth defect
 - type: simple
+  source: http://ncdj.org/style-guide/
+  note: Assumes that a person with a disability has a reduced quality of life.
   considerate:
     - person with a disability
     - people with disabilities
@@ -32,13 +34,19 @@
   considerate:
     - people with intellectual disabilities
   inconsiderate:
-    - intellectually disabled people
+    - sabled people
 - type: simple
   source: http://ncdj.org/style-guide/
   considerate:
     - person with an intellectual disability
   inconsiderate:
     - intellectually disabled
+- type: simple
+  source: http://ncdj.org/style-guide/
+  note: Assumes that a person with an intellectually disability has a reduced quality of life.
+  considerate:
+    - person with an intellectual disability
+  inconsiderate:
     - suffers from intellectual disabilities
     - suffering from intellectual disabilities
     - suffering from an intellectual disability

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -214,6 +214,7 @@
     - able-bodied
 - type: simple
   source: http://ncdj.org/style-guide/
+  note: Addiction is a neurobiological disease.
   considerate:
     - person with a drug addiction
     - person recovering from a drug addiction
@@ -221,6 +222,7 @@
     - addict
 - type: simple
   source: http://ncdj.org/style-guide/
+  note: Addiction is a neurobiological disease.
   considerate:
     - people with a drug addiction
     - people recovering from a drug addiction
@@ -228,6 +230,7 @@
     - addicts
 - type: simple
   source: http://ncdj.org/style-guide/
+  note: Alcoholism is a neurobiological disease.
   considerate:
     - someone with an alcohol problem
   inconsiderate:

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -80,14 +80,27 @@
     - moronic
     - nuts
 - type: simple
+  source: http://ncdj.org/style-guide/
+  note: Only refer to terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:
     - fluctuating
-    - person with schizophrenia
     - person with bipolar disorder
   inconsiderate:
     - bipolar
+- type: simple
+  source: http://ncdj.org/style-guide/
+  note: Only refer to terms describing mental illness when referring to a professionally diagnosed medical condition.
+  considerate:
+    - person with schizophrenia
+  inconsiderate:
     - schizophrenic
     - schizo
+- type: simple
+  source: http://ncdj.org/style-guide/
+  note: Assumes a person with schizophrenia experiences a reduced quality of life.
+  considerate:
+    - person with schizophrenia
+  inconsiderate:
     - suffers from schizophrenia
     - suffering from schizophrenia
     - afflicted with schizophrenia

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -233,7 +233,6 @@
     - non-disabled
   inconsiderate:
     - ablebodied
-    - able-bodied
 - type: simple
   source: http://ncdj.org/style-guide/
   note: Addiction is a neurobiological disease.

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ test('retext-equality', function(t) {
   t.same(
     process('Two bipolar magnets.'),
     [
-      '1:5-1:12: `bipolar` may be insensitive, use `fluctuating`, `person with schizophrenia`, `person with bipolar disorder` instead'
+      '1:5-1:12: `bipolar` may be insensitive, use `fluctuating`, `person with bipolar disorder` instead'
     ],
     '`bipolar` (without dash)'
   )
@@ -105,7 +105,7 @@ test('retext-equality', function(t) {
   t.same(
     process('Two bi-polar magnets.'),
     [
-      '1:5-1:13: `bi-polar` may be insensitive, use `fluctuating`, `person with schizophrenia`, `person with bipolar disorder` instead'
+      '1:5-1:13: `bi-polar` may be insensitive, use `fluctuating`, `person with bipolar disorder` instead'
     ],
     '`bi-polar` (with dash)'
   )


### PR DESCRIPTION
I used the National Center on Disability and Journalism's style guide recommendations to add some additional notes for the ableism script. (http://ncdj.org/style-guide/) 

in response to this issue in the alex repo: https://github.com/get-alex/alex/issues/219

-I used the sentence "Only use terms describing mental illness when referring to a professionally diagnosed medical condition." to try to reflect the idea that we shouldn't be using medical terms as an insults or pejorative descriptors. 

-I separated out the suggestions on schizophrenia and bipolar disorder, it didn't seem quite right to suggest that "schizophrenic" could be replaced by "person with bipolar disorder" for example. 

-I added a note that addiction is considered a disease, to underscore that it is not to be discussed in a pejorative sense. 

-I added notes clarifying why not to use language like "suffering from"