### PR TITLE
Remove "autistic" rule

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -59,7 +59,6 @@ And-patterns operate on a per-paragraph level.
 | `addict` | [simple](#simple) | `addict` | `person with a drug addiction`, `person recovering from a drug addiction` |
 | `addicts` | [simple](#simple) | `addicts` | `people with a drug addiction`, `people recovering from a drug addiction` |
 | `alcoholic` | [simple](#simple) | `alcoholic` | `someone with an alcohol problem` |
-| `autistic` | [simple](#simple) | `autistic` | `person with autism spectrum disorder` |
 | `deafmute` | [simple](#simple) | `deaf and dumb`, `deafmute` | `deaf` |
 | `senile` | [simple](#simple) | `demented`, `senile` | `person with dementia` |
 | `depressed` | [simple](#simple) | `depressed` | `sad`, `blue`, `bummed out`, `person with seasonal affective disorder`, `person with psychotic depression`, `person with postpartum depression` |

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -259,12 +259,6 @@
 - type: simple
   source: http://ncdj.org/style-guide/
   considerate:
-    - person with autism spectrum disorder
-  inconsiderate:
-    - autistic
-- type: simple
-  source: http://ncdj.org/style-guide/
-  considerate:
     - deaf
   inconsiderate:
     - deaf and dumb


### PR DESCRIPTION
Opinions among autistic people [vary] as to whether to prefer "autistic person" or "person with autism". Additionally, the [source cited] for this rule does not take a side in this debate. This project shouldn't, either, so I'm removing the rule entirely. (See #56)

[vary]: http://autisticadvocacy.org/about-asan/identity-first-language/
[source cited]: http://ncdj.org/style-guide/