### PR TITLE
Add alternatives for `sane`, `sanity check`

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -36,6 +36,8 @@ And-patterns operate on a per-paragraph level.
 | `intellectually-disabled-people` | [simple](#simple) | `intellectually disabled people` | `people with intellectual disabilities` |
 | `intellectually-disabled` | [simple](#simple) | `intellectually disabled`, `has intellectual issues`, `suffers from intellectual disabilities`, `suffering from intellectual disabilities`, `suffering from an intellectual disability`, `afflicted with intellectual disabilities`, `afflicted with a intellectual disability` | `person with an intellectual disability` |
 | `nuts` | [simple](#simple) | `batshit`, `psycho`, `crazy`, `delirious`, `insane`, `insanity`, `loony`, `lunacy`, `lunatic`, `mentally ill`, `psychopathology`, `mental defective`, `moron`, `moronic`, `nuts`, `mental case`, `mental` | `rude`, `malicious`, `mean`, `disgusting`, `vile`, `person with symptoms of mental illness`, `person with mental illness`, `person with symptoms of a mental disorder`, `person with a mental disorder` |
+| `sane` | [simple](#simple) | `sane` | `correct`, `adequate`, `sufficient`, `consistent`, `valid`, `coherent` |
+| `sanity-check` | [simple](#simple) | `sanity check` | `check`, `assertion`, `validation`, `smoke test` |
 | `bipolar` | [simple](#simple) | `bipolar` | `fluctuating`, `person with bipolar disorder` |
 | `schizo` | [simple](#simple) | `schizophrenic`, `schizo` | `person with schizophrenia` |
 | `manic` | [simple](#simple) | `suffers from schizophrenia`, `suffering from schizophrenia`, `afflicted with schizophrenia`, `manic` | `person with schizophrenia` |

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -86,7 +86,7 @@
     - mental case
     - mental
 - type: simple
-  note: When describing a mathematical or programmatic value, using the word "sane" needlessly invokes the topic of mental health.  Consider using a domain-specific or neutral term instead.
+  note: When describing a mathematical or programmatic value, using the word “sane” needlessly invokes the topic of mental health.  Consider using a domain-specific or neutral term instead.
   considerate:
     - correct
     - adequate

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -96,7 +96,7 @@
     - coherent
   inconsiderate: sane
 - type: simple
-  note: When describing a mathematical or programmatic value, using the phrase "sanity check" needlessly invokes the topic of mental health.  Consider using simply "check", or a domain-specific or neutral term, instead.
+  note: When describing a mathematical or programmatic value, using the phrase “sanity check” needlessly invokes the topic of mental health.  Consider using simply “check”, or a domain-specific or neutral term, instead.
   considerate:
     - check
     - assertion

--- a/script/ablist.yml
+++ b/script/ablist.yml
@@ -86,6 +86,24 @@
     - mental case
     - mental
 - type: simple
+  note: When describing a mathematical or programmatic value, using the word "sane" needlessly invokes the topic of mental health.  Consider using a domain-specific or neutral term instead.
+  considerate:
+    - correct
+    - adequate
+    - sufficient
+    - consistent
+    - valid
+    - coherent
+  inconsiderate: sane
+- type: simple
+  note: When describing a mathematical or programmatic value, using the phrase "sanity check" needlessly invokes the topic of mental health.  Consider using simply "check", or a domain-specific or neutral term, instead.
+  considerate:
+    - check
+    - assertion
+    - validation
+    - smoke test
+  inconsiderate: sanity check
+- type: simple
   source: https://ncdj.org/style-guide/
   note: Only use terms describing mental illness when referring to a professionally diagnosed medical condition.
   considerate:

--- a/test.js
+++ b/test.js
@@ -212,6 +212,22 @@ test('Phrasing', function(t) {
   )
 
   t.same(
+    process('First we check if the value is sane:'),
+    [
+      '1:32-1:36: `sane` may be insensitive, use `correct`, `adequate`, `sufficient`, `consistent`, `valid`, `coherent` instead'
+    ],
+    'First we check if the value is sane:'
+  )
+
+  t.same(
+    process("Let's do a quick sanity check here."),
+    [
+      '1:18-1:24: `sanity check` may be insensitive, use `check`, `assertion`, `validation`, `smoke test` instead'
+    ],
+    "Let's do a quick sanity check here."
+  )
+
+  t.same(
     process('I like him.'),
     [
       '1:8-1:11: `him` may be insensitive, when referring to a person, use `their`, `theirs`, `them` instead'


### PR DESCRIPTION
When describing a check on a mathematical or programmatic value, using the terms "sane" or "sanity check" needlessly invokes the topic of mental health.  It may be more considerate to use simply "check", or a domain-specific or neutral term, instead.

Related: get-alex/alex#62