### PR TITLE
Add alternatives for 'hang', 'hanged'

### DIFF
--- a/data/en/suicide.yml
+++ b/data/en/suicide.yml
@@ -38,3 +38,12 @@
     - a note from the deceased
   inconsiderate:
     - suicide note
+- type: simple
+  note: When describing the behavior of computer software, using the word “hanged” needlessly invokes the topic of death by self-harm or lynching.  Consider using the phrase “stopped responding to events” or “became unresponsive” instead.
+  considerate:
+    - the app stopped responding
+    - the app stopped responding to events
+    - the app became unresponsive
+  inconsiderate:
+    - hang
+    - hanged

--- a/rules.md
+++ b/rules.md
@@ -423,3 +423,4 @@ This is used for one case: `master` and `slave`.
 | `suicide-pact` | [simple](#simple) | `suicide epidemic`, `epidemic of suicides`, `suicide pact` | `rise in suicides` |
 | `failed-suicide` | [simple](#simple) | `failed suicide`, `failed attempt`, `suicide failure` | `suicide attempt`, `attempted suicide` |
 | `suicide-note` | [simple](#simple) | `suicide note` | `a note from the deceased` |
+| `hang` | [simple](#simple) | `hang`, `hanged` | `the app stopped responding`, `the app stopped responding to events`, `the app became unresponsive` |

--- a/test.js
+++ b/test.js
@@ -515,6 +515,15 @@ test('Phrasing', function(t) {
     ],
     'a.d.h.d'
   )
+  t.same(
+    process(
+      'The app hanged when dragging a window between a non-Retina and a Retina display'
+    ),
+    [
+      '1:9-1:15: `hanged` may be insensitive, use `the app stopped responding`, `the app stopped responding to events`, `the app became unresponsive` instead'
+    ],
+    'hang'
+  )
 
   t.end()
 })


### PR DESCRIPTION
When describing the behavior of computer software, using the word “hanged” needlessly invokes the topic of death by self-harm or lynching.  Consider using the phrase “stopped responding” or “stopped responding to events” instead.