### PR TITLE
Fix a little typo on lgbtq.yml

### DIFF
--- a/data/en/lgbtq.yml
+++ b/data/en/lgbtq.yml
@@ -123,7 +123,7 @@
 - type: simple
   source: https://www.glaad.org/reference/transgender
   considerate:
-    - being trangender
+    - being transgender
     - the movement for transgender equality
   inconsiderate:
     - transgenderism


### PR DESCRIPTION
A typo fix from _trangender_ to _tran**s**gender_.

On `data/en/lgbtq.yml` file there was a little typo, similar to the one I found last Hacktoberfest when I was looking at this project. Hope this helps.

