### PR TITLE
Update lodash to fix vulnerability

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -3,8 +3,8 @@
 module.exports = factory
 
 var keys = require('object-keys')
-var difference = require('lodash.difference')
-var intersection = require('lodash.intersection')
+var difference = require('lodash/difference')
+var intersection = require('lodash/intersection')
 var search = require('nlcst-search')
 var visit = require('unist-util-visit')
 var convert = require('unist-util-is/convert')

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "index.js"
   ],
   "dependencies": {
-    "lodash": ">= 4.17.5",
+    "lodash": "^4.17.5",
     "nlcst-normalize": "^2.0.0",
     "nlcst-search": "^1.1.1",
     "nlcst-to-string": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "index.js"
   ],
   "dependencies": {
-    "lodash.difference": "^4.5.0",
-    "lodash.intersection": "^4.4.0",
+    "lodash": ">= 4.17.5",
     "nlcst-normalize": "^2.0.0",
     "nlcst-search": "^1.1.1",
     "nlcst-to-string": "^2.0.0",


### PR DESCRIPTION
[Lodash versions prior to 4.17.5 are vulnerable to Prototype Pollution](https://www.npmjs.com/advisories/577).
This PR updates lodash to 4.17.5

<!--
Read the [contributing guidelines](https://github.com/retextjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/retextjs/.github/blob/master/support.md
https://github.com/retextjs/.github/blob/master/contributing.md
-->
