### PR TITLE
Clarify the Jewish references in the data

### DIFF
--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -196,11 +196,9 @@
   considerate:
     - Jewish person
   inconsiderate:
-    - kike
     - shlomo
     - shyster
     - hymie
-    - jewboy
 - type: basic
   considerate:
     - a person who is not Jewish
@@ -208,7 +206,6 @@
   inconsiderate:
     - goyim
     - goyum
-    - shiksa
     - goy
 - type: basic
   considerate:

--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -197,9 +197,19 @@
     - Jewish person
   inconsiderate:
     - kike
-    - goyum
-    - goy
     - shlomo
+    - shyster
+    - hymie
+    - jewboy
+- type: basic
+  considerate:
+    - a person who is not Jewish
+    - not Jewish
+  inconsiderate:
+    - goyim
+    - goyum
+    - shiksa
+    - goy
 - type: basic
   considerate:
     - a Black person

--- a/rules.md
+++ b/rules.md
@@ -417,7 +417,8 @@ This is used for one case: `master` and `slave`.
 | `towel-heads` | [basic](#basic) | `sand niggers`, `towel heads` | `Arabs`, `Middle Eastern People` |
 | `latino` | [basic](#basic) | `latino`, `latina`, `mexican` | `Latinx` |
 | `japs` | [basic](#basic) | `japs` | `Japanese person`, `Japanese people` |
-| `goy` | [basic](#basic) | `kike`, `goyum`, `goy`, `shlomo` | `Jewish person` |
+| `kike` | [basic](#basic) | `kike`, `shlomo`, `shyster`, `hymie`, `jewboy` | `Jewish person` |
+| `goy` | [basic](#basic) | `goyim`, `goyum`, `shiksa`, `goy` | `a person who is not Jewish`, `not Jewish` |
 | `spade` | [basic](#basic) | `spade` | `a Black person` |
 | `gyp` | [basic](#basic) | `gyppo`, `gypsy`, `Gipsy`, `gyp` | `Nomad`, `Traveler`, `Roma`, `Romani` |
 | `blacklist` | [basic](#basic) | `blacklist` | `blocklist`, `wronglist`, `banlist`, `deny list` |


### PR DESCRIPTION
The `race.yml` file currently conflates inconsiderate references for both Jewish and non-Jewish people. This pull request breaks them out into two separate categories, and adds a few more common examples to both.