### PR TITLE
Remove conflicting recommendation of changing 'madmen' to 'maniacs'

### DIFF
--- a/data/en/gender.yml
+++ b/data/en/gender.yml
@@ -1473,7 +1473,8 @@
     mad man: male
 - type: basic
   considerate:
-    - maniacs
+    - fanatics
+    - zealots
     - enthusiasts
   inconsiderate:
     madmen: male

--- a/rules.md
+++ b/rules.md
@@ -312,7 +312,7 @@ This is used for one case: `master` and `slave`.
 | `masterplan` | [basic](#basic) | `masterplan` | `vision`, `comprehensive plan` |
 | `masterstroke` | [basic](#basic) | `masterstroke` | `trump card`, `stroke of genius` |
 | `madman` | [basic](#basic) | `madman`, `mad man` | `fanatic`, `zealot`, `enthusiast` |
-| `madmen` | [basic](#basic) | `madmen`, `mad men` | `maniacs`, `enthusiasts` |
+| `madmen` | [basic](#basic) | `madmen`, `mad men` | `fanatics`, `zealots`, `enthusiasts` |
 | `mankind` | [basic](#basic) | `mankind` | `humankind` |
 | `manhour` | [basic](#basic) | `manhour`, `man hour` | `staff hour`, `hour of work` |
 | `manhours` | [basic](#basic) | `manhours`, `man hours` | `staff hours`, `hours of work`, `hours of labor`, `hours` |


### PR DESCRIPTION
`data/en/ablist.yml` recommends against the word "maniac", providing a citation:
```yaml
- type: simple
  source: https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html
  …
  inconsiderate:
    - maniac
```

…yet `data/en/gender.yml` suggests "maniacs":
```yaml
- type: simple
  considerate:
    - maniacs
    - enthusiasts
  inconsiderate:
    madmen: male
    mad men: male
```

This PR brings the "madmen" (plural) recommendations in line with the "madman" (singular) recommendations, and removes the conflicting "maniac" recommendation.
