### PR TITLE
Update whitelist/blacklist to include two word version

### DIFF
--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -234,6 +234,7 @@
     - deny list
   inconsiderate:
     - blacklist
+    - black list
 - type: basic
   note: Replace racially-charged language with more accurate and inclusive words
   considerate:
@@ -243,6 +244,7 @@
     - allow list
   inconsiderate:
     - whitelist
+    - white list
 - type: basic
   note: Avoid using terms that imply a group has not changed over time and that they are inferior
   considerate:

--- a/rules.md
+++ b/rules.md
@@ -421,8 +421,8 @@ This is used for one case: `master` and `slave`.
 | `goy` | [basic](#basic) | `goyim`, `goyum`, `goy` | `a person who is not Jewish`, `not Jewish` |
 | `spade` | [basic](#basic) | `spade` | `a Black person` |
 | `gyp` | [basic](#basic) | `gyppo`, `gypsy`, `Gipsy`, `gyp` | `Nomad`, `Traveler`, `Roma`, `Romani` |
-| `blacklist` | [basic](#basic) | `blacklist` | `blocklist`, `wronglist`, `banlist`, `deny list` |
-| `whitelist` | [basic](#basic) | `whitelist` | `passlist`, `alrightlist`, `safelist`, `allow list` |
+| `blacklist` | [basic](#basic) | `blacklist`, `black list` | `blocklist`, `wronglist`, `banlist`, `deny list` |
+| `whitelist` | [basic](#basic) | `whitelist`, `white list` | `passlist`, `alrightlist`, `safelist`, `allow list` |
 | `savage` | [basic](#basic) | `primitive`, `savage`, `stone age` | `simple`, `indigenous`, `hunter-gatherer` |
 | `tribe` | [basic](#basic) | `tribe` | `society`, `community` |
 | `sophisticated-culture` | [basic](#basic) | `sophisticated culture` | `complex culture` |


### PR DESCRIPTION
Catch and report 'whitelist' and 'blacklist' when they're used as two separate words. Eg 'white list' and 'black list'
