### PR TITLE
Add `pattern` to vfile message

### DIFF
--- a/lib/factory.js
+++ b/lib/factory.js
@@ -155,15 +155,16 @@ function factory(patterns, lang) {
       match = matches[index]
       nodes = match.nodes
 
-      warn(
+      warn({
         file,
         id,
-        toString(nodes),
-        pattern.considerate,
-        nodes[0],
+        actual: toString(nodes),
+        suggestion: pattern.considerate,
+        node: nodes[0],
         note,
-        pattern.condition
-      )
+        condition: pattern.condition,
+        pattern
+      })
     }
   }
 
@@ -219,20 +220,31 @@ function factory(patterns, lang) {
         }
       }
 
-      warn(
+      warn({
         file,
         id,
-        value,
-        pattern.considerate,
-        nodes[0],
+        actual: value,
+        suggestion: pattern.considerate,
+        node: nodes[0],
         note,
-        pattern.condition
-      )
+        condition: pattern.condition,
+        pattern
+      })
     }
   }
 
   // Warn on `file` about `actual` (at `node`) with `suggestion`s.
-  function warn(file, id, actual, suggestion, node, note, condition, joiner) {
+  function warn({
+    file,
+    id,
+    actual,
+    suggestion,
+    node,
+    note,
+    condition,
+    joiner,
+    pattern
+  }) {
     var expected = suggestion
     var message
 
@@ -252,6 +264,7 @@ function factory(patterns, lang) {
 
     message.actual = actual
     message.expected = expected
+    message.pattern = pattern
 
     if (note) {
       message.note = note

--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
     "build": "npm run build-bundle && npm run build-mangle",
     "test-api": "node test",
     "test-coverage": "nyc --reporter lcov tape test.js",
-    "test": "npm run generate && npm run format && npm run build && npm run test-coverage"
+    "build-all": "npm run generate && npm run format && npm run build",
+    "test": "npm run build-all && npm run test-coverage",
+    "postinstall": "npm run build-all"
   },
   "nyc": {
     "check-coverage": true,

--- a/script/generate.js
+++ b/script/generate.js
@@ -77,7 +77,8 @@ function generateLanguage(info) {
       considerate: clean(entry.considerate),
       inconsiderate: inconsiderate,
       condition: entry.condition,
-      note: note
+      note: note,
+      source
     }
   })
 

--- a/test.js
+++ b/test.js
@@ -40,6 +40,20 @@ test('retext-equality', function (t) {
         'person with a disability',
         'people with disabilities'
       ],
+      pattern: {
+        id: 'birth-defect',
+        type: 'basic',
+        categories: ['a'],
+        considerate: {
+          'has a disability': 'a',
+          'person with a disability': 'a',
+          'people with disabilities': 'a'
+        },
+        inconsiderate: {'birth defect': 'a'},
+        note:
+          'Assumes/implies that a person with a disability is deficient or inferior to others. When possible, specify the functional ability or its restriction. (source: https://ncdj.org/style-guide/)',
+        source: 'https://ncdj.org/style-guide/'
+      },
       note:
         'Assumes/implies that a person with a disability is deficient or inferior to others. When possible, specify the functional ability or its restriction. (source: https://ncdj.org/style-guide/)'
     },


### PR DESCRIPTION
This PR adds the `pattern` object to the message payload that the user will receive after parsing the text.

### Why?

Some users may wish to use some of the original data for their own use case. For example, I would like to use the `source` URL directly

### How?

Modifies the `warn` function to accept a single object parameter, rather than many arguments. Then, passes `pattern` to this object wherever `warn` is used.