### PR TITLE
Add rules for white/blacklist verb forms

### DIFF
--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -235,6 +235,24 @@
 - type: basic
   note: Replace racially-charged language with more accurate and inclusive words
   considerate:
+    - blocklisted
+    - wronglisted
+    - banlisted
+    - deny-listed
+  inconsiderate:
+    - blacklisted
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
+    - blocklisting
+    - wronglisting
+    - banlisting
+    - deny-listing
+  inconsiderate:
+    - blacklisting
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
     - passlist
     - alrightlist
     - safelist
@@ -242,6 +260,40 @@
   inconsiderate:
     - whitelist
     - white list
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
+    - passlisted
+    - alrightlisted
+    - safelisted
+    - allow-listed
+  inconsiderate:
+    - whitelisted
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
+    - passlisting
+    - alrightlisting
+    - safelisting
+    - allow-listing
+  inconsiderate:
+    - whitelisting
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
+    - space
+    - blank
+  inconsiderate:
+    - whitespace
+    - white space
+- type: basic
+  note: Replace racially-charged language with more accurate and inclusive words
+  considerate:
+    - space
+    - blank
+  inconsiderate:
+    - whitespaces
+    - white spaces
 - type: basic
   note: Avoid using terms that imply a group has not changed over time and that they are inferior
   considerate:

--- a/rules.md
+++ b/rules.md
@@ -415,7 +415,13 @@ true`, thus suggesting two alternatives for `him or her`.
 | `spade` | [basic](#basic) | `spade` | `a Black person` |
 | `gyp` | [basic](#basic) | `gyppo`, `gypsy`, `Gipsy`, `gyp` | `Nomad`, `Traveler`, `Roma`, `Romani` |
 | `blacklist` | [basic](#basic) | `blacklist`, `black list` | `blocklist`, `wronglist`, `banlist`, `deny list` |
+| `blacklisted` | [basic](#basic) | `blacklisted` | `blocklisted`, `wronglisted`, `banlisted`, `deny-listed` |
+| `blacklisting` | [basic](#basic) | `blacklisting` | `blocklisting`, `wronglisting`, `banlisting`, `deny-listing` |
 | `whitelist` | [basic](#basic) | `whitelist`, `white list` | `passlist`, `alrightlist`, `safelist`, `allow list` |
+| `whitelisted` | [basic](#basic) | `whitelisted` | `passlisted`, `alrightlisted`, `safelisted`, `allow-listed` |
+| `whitelisting` | [basic](#basic) | `whitelisting` | `passlisting`, `alrightlisting`, `safelisting`, `allow-listing` |
+| `whitespace` | [basic](#basic) | `whitespace`, `white space` | `space`, `blank` |
+| `whitespaces` | [basic](#basic) | `whitespaces`, `white spaces` | `space`, `blank` |
 | `savage` | [basic](#basic) | `primitive`, `savage`, `stone age` | `simple`, `indigenous`, `hunter-gatherer` |
 | `tribe` | [basic](#basic) | `tribe` | `society`, `community` |
 | `sophisticated-culture` | [basic](#basic) | `sophisticated culture` | `complex culture` |

--- a/test.js
+++ b/test.js
@@ -479,6 +479,13 @@ test('Phrasing', function (t) {
     ],
     'hang'
   )
+  t.same(
+    process('The user has been whitelisted.'),
+    [
+      '1:19-1:30: `whitelisted` may be insensitive, use `passlisted`, `alrightlisted`, `safelisted`, `allow-listed` instead'
+    ],
+    'whitelist'
+  )
 
   t.end()
 })


### PR DESCRIPTION
While checking external assets for offensive language using Alex I noticed that a bunch of cases slipped - namely those where "whitelist" (and similar terms) were used in the form of declined verbs. Note that I added tests for only one case since I found that there was no test whatsoever for "whitelist" etc.