### PR TITLE
Added gender pronoun rule to lgbtq

### DIFF
--- a/data/en/lgbtq.yml
+++ b/data/en/lgbtq.yml
@@ -193,3 +193,14 @@
     - she male
     - heshe
     - shehe
+- type: basic
+  source: https://www.selfdefined.app/definitions/pronouns/
+  note: Preferred pronoun sounds like it is optional to use someone's correct pronoun
+  considerate:
+    - pronoun
+    - pronouns
+  inconsiderate:
+    - preferred pronoun
+    - preferred pronouns
+    - gender pronoun
+    - gender pronouns

--- a/rules.md
+++ b/rules.md
@@ -385,6 +385,7 @@ true`, thus suggesting two alternatives for `him or her`.
 | `hermaphroditic` | [basic](#basic) | `hermaphroditic`, `pseudohermaphroditic`, `pseudo hermaphroditic` | `intersex` |
 | `hermaphrodite` | [basic](#basic) | `hermaphrodite`, `pseudohermaphrodite`, `pseudo hermaphrodite` | `person who is intersex`, `person`, `intersex person` |
 | `heshe` | [basic](#basic) | `shemale`, `she male`, `heshe`, `shehe` | `transgender person`, `person` |
+| `gender-pronoun` | [basic](#basic) | `preferred pronoun`, `preferred pronouns`, `gender pronoun`, `gender pronouns` | `pronoun`, `pronouns` |
 | `islamist` | [basic](#basic) | `islamist` | `muslim`, `person of Islamic faith`, `fanatic`, `zealot`, `follower of islam`, `follower of the islamic faith` |
 | `islamists` | [basic](#basic) | `islamists` | `muslims`, `people of Islamic faith`, `fanatics`, `zealots` |
 | `master` | [basic](#basic) | `master` | `primary`, `hub`, `reference` |

--- a/test.js
+++ b/test.js
@@ -486,6 +486,13 @@ test('Phrasing', function (t) {
     ],
     'whitelist'
   )
+  t.same(
+    process('Please use your preferred pronoun'),
+    [
+      '1:17-1:26: `preferred pronoun` may be insensitive, use `pronoun`, `pronouns` instead'
+    ],
+    'preferred pronoun'
+  )
 
   t.end()
 })


### PR DESCRIPTION
 I learned from https://www.selfdefined.app/definitions/pronouns/ that it's better to say "pronouns" instead of "preferred pronouns". It's not optional to use someone's correct pronouns. I added a new rule and a test