### PR TITLE
Add rule and test for ablist term dummy

### DIFF
--- a/data/en/ablist.yml
+++ b/data/en/ablist.yml
@@ -668,3 +668,15 @@
     - adhd
     - a.d.d.
     - a.d.h.d.
+- type: basic
+  note: Dummy can refer to the inability to talk or be used as a derogatory word meaning stupid. In computer programming it is used where a value or behavior is unimportant. There are better alternatives for other use cases also.
+  considerate:
+    - test double
+    - placeholder
+    - fake
+    - stub
+  inconsiderate:
+    - dummyvariable
+    - dummyvalue
+    - dummyobject
+    - dummy

--- a/test.js
+++ b/test.js
@@ -493,6 +493,16 @@ test('Phrasing', function (t) {
     ],
     'preferred pronoun'
   )
+  t.same(
+    process(
+      'The value held in the _dummyVariable will be ignored, as will dummy workflow methods.'
+    ),
+    [
+      '1:24-1:37: `dummyVariable` may be insensitive, use `test double`, `placeholder`, `fake`, `stub` instead',
+      '1:63-1:68: `dummy` may be insensitive, use `test double`, `placeholder`, `fake`, `stub` instead'
+    ],
+    'dummy'
+  )
 
   t.end()
 })


### PR DESCRIPTION
Similar to the word _dumb_ (already included), _dummy_ can refer to the inability to talk or be used as a derogatory word like _stupid_.

_Dummy_ has become normalized when identifying and/or substituting variables or functions in programming (particularly testing) where value or behaviour is unimportant e.g.

```csharp
var _dummyValue = 2;
var DummyObject = new Person();
```

This is then reflected in markdown documentation also.

It has also become a [significant feature in FakeItEasy](https://fakeiteasy.readthedocs.io/en/stable/dummies/).

There are better alternatives that are less likely to cause offense i.e.

- test double
- placeholder
- fake
- stub
