### PR TITLE
Remove suggestion of `latinx` for `Mexican`

### DIFF
--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -182,7 +182,6 @@
   inconsiderate:
     - latino
     - latina
-    - mexican
 - type: basic
   considerate:
     - Japanese person


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [ x ] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [ x ] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [ x ] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [ x ] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->

### Description of changes

This resolves #113 by removing "Mexican" from the list of inconsiderate terms to be replaced with "Latinx".

<!--do not edit: pr-->
