### PR TITLE
Remove whitespace and its variants from list of racial words

### DIFF
--- a/data/en/race.yml
+++ b/data/en/race.yml
@@ -308,22 +308,6 @@
   inconsiderate:
     - whitelisting
 - type: basic
-  note: Replace racially-charged language with more accurate and inclusive words
-  considerate:
-    - space
-    - blank
-  inconsiderate:
-    - whitespace
-    - white space
-- type: basic
-  note: Replace racially-charged language with more accurate and inclusive words
-  considerate:
-    - space
-    - blank
-  inconsiderate:
-    - whitespaces
-    - white spaces
-- type: basic
   note: Avoid using terms that imply a group has not changed over time and that they are inferior
   considerate:
     - simple


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Remove the word 'whitespace' and its spelling variants from the list of racial words.
The word 'white' in it does not refer to skin color but rather to the color of paper on which text is printed.

<!--do not edit: pr-->