### PR TITLE
Fix bad URL w/ `archive.org` snapshot

### DIFF
--- a/data/en/ablist.yml
+++ b/data/en/ablist.yml
@@ -498,7 +498,7 @@
   inconsiderate:
     - dumb
 - type: basic
-  source: http://www.mmonjejr.com/2014/02/deconstructing-stupid.html
+  source: https://web.archive.org/web/20181025174508/http://www.mmonjejr.com:80/2014/02/deconstructing-stupid.html
   considerate:
     - foolish
     - ludicrous


### PR DESCRIPTION
The current content of the URL is NSFW.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Replace the URL for "stupid" with the last valid snapshot in archive.org. Browsing to the existing URL on an employer's computer was.... interesting.

<!--do not edit: pr-->
