### PR TITLE
Remove "prostitute" as a considerate form of "call-girl"

### DIFF
--- a/data/en/gender.yml
+++ b/data/en/gender.yml
@@ -1589,7 +1589,6 @@
   source: https://radyananda.wordpress.com/2009/06/06/nonsexist-alternative-language-handbook-for-conscious-writers/
   considerate:
     - escort
-    - prostitute
     - sex worker
   inconsiderate: call girl
 - type: basic

--- a/data/en/gender.yml
+++ b/data/en/gender.yml
@@ -1745,6 +1745,12 @@
   considerate: poet
   inconsiderate: poetess
 - type: basic
+  source: https://www.nswp.org/sites/default/files/terminology_guide_english_prf03.pdf
+  considerate:
+    - sex worker
+    - escort
+  inconsiderate: prostitute
+- type: basic
   source: https://radyananda.wordpress.com/2009/06/06/nonsexist-alternative-language-handbook-for-conscious-writers/
   considerate: railway worker
   inconsiderate: railwayman

--- a/rules.md
+++ b/rules.md
@@ -83,7 +83,7 @@ to allow them.
 | `buckteeth` | [basic](#basic) | `bucktoothed`, `buckteeth` | `person with prominent teeth`, `prominent teeth` |
 | `bugreport` | [basic](#basic) | `bugreport` | `bug report`, `snapshot` |
 | `calendar-girl` | [basic](#basic) | `calendar girl` | `model` |
-| `call-girl` | [basic](#basic) | `call girl` | `escort`, `prostitute`, `sex worker` |
+| `call-girl` | [basic](#basic) | `call girl` | `escort`, `sex worker` |
 | `cameraman-camerawoman` | [or](#or) | `camerawoman` (female), `cameraman` (male) | `camera operator`, `camera person` |
 | `cameramen-camerawomen` | [or](#or) | `camerawomen` (female), `cameramen` (male) | `camera operators` |
 | `cattleman-cattlewoman` | [or](#or) | `cattlewoman` (female), `cattleman` (male) | `cattle rancher` |

--- a/rules.md
+++ b/rules.md
@@ -340,6 +340,7 @@ to allow them.
 | `powwow` | [basic](#basic) | `pow wow`, `powwow` | `conference`, `gathering`, `meeting` |
 | `prince-princess` | [or](#or) | `princess` (female), `prince` (male) | `heir` |
 | `princes-princesses` | [or](#or) | `princesses` (female), `princes` (male) | `heirs` |
+| `prostitute` | [basic](#basic) | `prostitute` | `sex worker`, `escort` |
 | `psychotic` | [basic](#basic) | `psychotic`, `suffers from psychosis`, `suffering from psychosis`, `afflicted with psychosis`, `victim of psychosis` | `person with a psychotic condition`, `person with psychosis` |
 | `pull-the-trigger` | [basic](#basic) | `pull the trigger` | `go for it`, `take a chance`, `make a move`, `take action` |
 | `quadriplegic` | [basic](#basic) | `quadriplegic` | `person with quadriplegia` |

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./test.js","./lib/create-plugin.js","./lib/en.js","./lib/patterns-en.js","./script/build-table.js","./script/generate.js"],"version":"5.8.2"}


### PR DESCRIPTION
Prostitute is not considered a polite term by sex workers. Sex workers may refer to themselves as prostitutes and there are certainly sex workers who don't care if others call them that but it shouldn't be used as a blanket term by non-sex workers.

Not sure if justification or sources are needed, I used to be a sex worker myself but I recognize that's impossible to prove without connecting identities I would rather stay separate, and one person isn't indicative of a community anyway. So I dug up some other opinions:

- [Terminology Guide by Global Network of Sex Work Projects](https://www.nswp.org/sites/default/files/terminology_guide_english_prf03.pdf)
- [Article by a sex worker in the Sydney Morning Herald](https://www.smh.com.au/lifestyle/life-and-relationships/why-the-word-prostitute-has-to-go-20180913-p503hj.html)

<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aretextjs&type=issues and https://github.com/orgs/retextjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Remove "prostitute" from "considerate" list of "call-girl", and update rules.md accordingly.

<!--do not edit: pr-->
